### PR TITLE
Update RPC client URL to production environment

### DIFF
--- a/src/lib/rpc.ts
+++ b/src/lib/rpc.ts
@@ -1,4 +1,4 @@
 import { hc } from 'hono/client'
 import { AppType } from '@/app/api/[[...route]]/route'
 
-export const client = hc<AppType>('http://localhost:3000')
+export const client = hc<AppType>('https://devminds-blog.vercel.app')


### PR DESCRIPTION
Change the RPC client URL to point to the production environment instead of the local development server.