### PR TITLE
Update on the maximum length for the full post description

### DIFF
--- a/src/features/posts/components/forms/post-form.tsx
+++ b/src/features/posts/components/forms/post-form.tsx
@@ -101,7 +101,7 @@ export function PostForm({
               <FormLabel>Full Description</FormLabel>
               <FormControl>
                 <Textarea
-                  maxLength={1000}
+                  maxLength={6000}
                   className="h-96 resize-none"
                   disabled={disabled}
                   placeholder={example.fullDescription}

--- a/src/features/posts/schemas.ts
+++ b/src/features/posts/schemas.ts
@@ -12,7 +12,7 @@ export const createPostSchema = z.object({
   fullDescription: z
     .string()
     .min(20, 'Minimum 20 characters required')
-    .max(1000, 'Maximum 1000 characters allowed'),
+    .max(6000, 'Maximum 6000 characters allowed'),
 })
 
 export const postIdSchema = z.string().min(10)


### PR DESCRIPTION
Update on the maximum length for the full post description because the posts are too short.

## Pending

- [ ] Change de max value for `fullDescription` in AppWrite